### PR TITLE
Implement mempool check for wd utxo

### DIFF
--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -369,6 +369,59 @@ pub async fn get_mempool_txs(
     Ok(txs)
 }
 
+pub async fn is_tx_on_chain(txid: &Txid, config: &BridgeCliConfig) -> Result<bool, BridgeCliError> {
+    match is_tx_on_chain_mempool_space(txid, config).await {
+        Ok(status) => Ok(status.confirmed),
+        Err(mempool_error) => {
+            tracing::warn!(
+                "Mempool API failed for is_tx_on_chain: {}, falling back to Bitcoin RPC",
+                mempool_error
+            );
+
+            if config.bitcoin_config.is_some() {
+                is_tx_on_chain_bitcoin_rpc(txid, config).await
+            } else {
+                Err(mempool_error)
+            }
+        }
+    }
+}
+
+async fn is_tx_on_chain_mempool_space(
+    txid: &Txid,
+    config: &BridgeCliConfig,
+) -> Result<UtxoStatus, BridgeCliError> {
+    if config.network == bitcoin::Network::Regtest {
+        tracing::warn!(
+            "Transaction status fetching using txid from mempool.space is disabled in regtest mode."
+        );
+        return Err(BridgeCliError::Eyre(eyre::eyre!(
+            "Transaction status fetching using txid is disabled in regtest mode."
+        )));
+    }
+
+    let url = config
+        .mempool_api_url
+        .join(&format!("tx/{}/status", txid))
+        .map_err(|e| BridgeCliError::Eyre(eyre::eyre!("Failed to join mempool_api_url: {e}")))?;
+    let resp = reqwest::get(url).await?.error_for_status()?;
+    let status: UtxoStatus = resp.json().await?;
+    Ok(status)
+}
+
+async fn is_tx_on_chain_bitcoin_rpc(
+    txid: &Txid,
+    config: &BridgeCliConfig,
+) -> Result<bool, BridgeCliError> {
+    let rpc = config.connect_to_bitcoin_rpc().await?;
+    Ok(rpc
+        .get_raw_transaction_info(txid, None)
+        .await
+        .ok()
+        .and_then(|s| s.blockhash)
+        .is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -371,7 +371,7 @@ pub async fn get_mempool_txs(
 
 pub async fn is_tx_on_chain(txid: &Txid, config: &BridgeCliConfig) -> Result<bool, BridgeCliError> {
     match is_tx_on_chain_mempool_space(txid, config).await {
-        Ok(status) => Ok(status.confirmed),
+        Ok(is_confirmed) => Ok(is_confirmed),
         Err(mempool_error) => {
             tracing::warn!(
                 "Mempool API failed for is_tx_on_chain: {}, falling back to Bitcoin RPC",
@@ -390,7 +390,7 @@ pub async fn is_tx_on_chain(txid: &Txid, config: &BridgeCliConfig) -> Result<boo
 async fn is_tx_on_chain_mempool_space(
     txid: &Txid,
     config: &BridgeCliConfig,
-) -> Result<UtxoStatus, BridgeCliError> {
+) -> Result<bool, BridgeCliError> {
     if config.network == bitcoin::Network::Regtest {
         tracing::warn!(
             "Transaction status fetching using txid from mempool.space is disabled in regtest mode."
@@ -406,7 +406,7 @@ async fn is_tx_on_chain_mempool_space(
         .map_err(|e| BridgeCliError::Eyre(eyre::eyre!("Failed to join mempool_api_url: {e}")))?;
     let resp = reqwest::get(url).await?.error_for_status()?;
     let status: UtxoStatus = resp.json().await?;
-    Ok(status)
+    Ok(status.confirmed)
 }
 
 async fn is_tx_on_chain_bitcoin_rpc(

--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -405,7 +405,9 @@ async fn is_tx_on_chain_mempool_space(
         .join(&format!("tx/{}/status", txid))
         .map_err(|e| BridgeCliError::Eyre(eyre::eyre!("Failed to join mempool_api_url: {e}")))?;
     let resp = reqwest::get(url).await?.error_for_status()?;
+    tracing::debug!("Is tx on chain from mempool.space response: {:?}", resp);
     let status: UtxoStatus = resp.json().await?;
+    tracing::debug!("Is tx on chain from mempool.space status: {:?}", status);
     Ok(status.confirmed)
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -176,7 +176,7 @@ pub enum BridgeCliError {
     #[error("Can't find the UTXO {0} in withdrawals")]
     CantFindUTXO(OutPoint),
 
-    #[error("Transaction {0} is not found on chain")]
+    #[error("Transaction {0} is not found on chain, maybe wait for confirmation")]
     TransactionNotOnChain(bitcoin::Txid),
 
     // Module specific errors

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -176,6 +176,9 @@ pub enum BridgeCliError {
     #[error("Can't find the UTXO {0} in withdrawals")]
     CantFindUTXO(OutPoint),
 
+    #[error("Transaction {0} is not found on chain")]
+    TransactionNotOnChain(bitcoin::Txid),
+
     // Module specific errors
     #[error("Can't get configuration: {0}")]
     ConfigError(ConfigErrors),

--- a/src/main.rs
+++ b/src/main.rs
@@ -696,8 +696,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             "Operator-paid withdrawal signature hex: {}",
                             serialize_and_encode(operator_signature)
                         );
-                        println!();
-                        println!("Now run:");
+                        println!("If the transaction that created your withdrawal UTXO is not yet confirmed, please wait for it to be confirmed before proceeding.");
+                        println!("After its confirmation run:");
                         println!();
                         println!("clementine-cli withdraw safe-withdraw --network {} {} {} {} {}",
                             network, &signer_address.address_with_prefix(), destination_address, withdrawal_utxo_outpoint, serialize_and_encode(optimistic_signature));

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -1,7 +1,7 @@
 // Withdrawal-related commands and logic for Clementine CLI
 
 use crate::BitcoinAddress;
-use crate::api_utils::{get_tx_details, get_utxos};
+use crate::api_utils::{get_tx_details, get_utxos, is_tx_on_chain};
 use crate::bitcoin_utils::{sign_withdrawal_signature, verify_withdrawal_signature};
 use crate::config::BridgeCliConfig;
 use crate::errors::BridgeCliError;
@@ -354,6 +354,12 @@ pub async fn prepare_withdrawal_params(
     BridgeCliError,
 > {
     // Get the prepare tx details
+    if !is_tx_on_chain(&withdrawal_outpoint.txid, config).await? {
+        return Err(BridgeCliError::TransactionNotOnChain(
+            withdrawal_outpoint.txid,
+        ));
+    }
+
     let (prepare_tx, prepare_tx_block, prepare_tx_block_height) =
         get_tx_details(&withdrawal_outpoint.txid, config).await?;
 

--- a/src/withdraw.rs
+++ b/src/withdraw.rs
@@ -353,13 +353,13 @@ pub async fn prepare_withdrawal_params(
     ),
     BridgeCliError,
 > {
-    // Get the prepare tx details
     if !is_tx_on_chain(&withdrawal_outpoint.txid, config).await? {
         return Err(BridgeCliError::TransactionNotOnChain(
             withdrawal_outpoint.txid,
         ));
     }
 
+    // Get the prepare tx details
     let (prepare_tx, prepare_tx_block, prepare_tx_block_height) =
         get_tx_details(&withdrawal_outpoint.txid, config).await?;
 


### PR DESCRIPTION
This PR implements mempool check for newly created withdrawal (dust) utxo. If not confirmed, gives error for send-safe-withdrawal.
Closes #128 